### PR TITLE
Fix PAC WIF version

### DIFF
--- a/lib/paccoinlib.py
+++ b/lib/paccoinlib.py
@@ -19,7 +19,7 @@ def is_valid_paccoin_address(address, network='mainnet'):
     # 4 checksum bytes are appended so the total number of
     # base58 encoded bytes should be 25.  This means the number of characters
     # in the encoding should be about 34 ( 25 * log2( 256 ) / log2( 58 ) ).
-    paccoin_version = 140 if network == 'testnet' else 76
+    paccoin_version = 120 if network == 'testnet' else 55
 
     # Check length (This is important because the base58 library has problems
     # with long addresses (which are invalid anyway).


### PR DESCRIPTION
This is causing that gobjects that are loaded from the daemon to be deemed as invalid, thus Sentinel votes to delete them.